### PR TITLE
Export setOptions and getOptions in index.d.ts.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -113,11 +113,6 @@ declare module "genshin-db" {
 		resultLanguage?: Language;
 	}
 
-
-	// not easy to figure this out
-	//export const setOptions: (options: QueryOptions): void 
-	//export const getOptions: ():
-
 	export const achievementgroups: QueryFunction<AchievementGroup>;
 	export const achievements: QueryFunction<Achievement>;
 	export const adventureranks: QueryFunction<AdventureRank>;
@@ -192,5 +187,8 @@ declare module "genshin-db" {
 	export function addData(data: ArrayBuffer | any, overwrite? : boolean): void;
 	export function searchFolder(folder: string, query: string, opts?: QueryOptions): any;
 	export function searchMultipleFolders(folders: string[], query: string, opts?: QueryOptions): any;
-
+        
+        // export functions to set / get queryOptions
+        export function setOptions(QueryOptions): void;
+        export function getOptions(): object;
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -187,8 +187,18 @@ declare module "genshin-db" {
 	export function addData(data: ArrayBuffer | any, overwrite? : boolean): void;
 	export function searchFolder(folder: string, query: string, opts?: QueryOptions): any;
 	export function searchMultipleFolders(folders: string[], query: string, opts?: QueryOptions): any;
-        
-        // export functions to set / get queryOptions
-        export function setOptions(QueryOptions): void;
-        export function getOptions(): object;
+
+	//#region Options
+
+	/**
+	 * Set options by providing the values you want to change.
+	 */
+	export function setOptions(opts: QueryOptions): void;
+
+	/**
+	 * Returns a cloned copy of the options.
+	 */
+	export function getOptions(): QueryOptions;
+
+	//#endregion
 }


### PR DESCRIPTION
This will allow using these two functions directly in Typescript. Without these two exports, an error like `Property 'setOptions' does not exist on type 'typeof import("genshin-db")'.` would occur.