### PR TITLE
Add missing `tcgenemycards` type definition and change `rarity` deprecated comment to JSDoc

### DIFF
--- a/types/enums.d.ts
+++ b/types/enums.d.ts
@@ -46,7 +46,8 @@ declare module "genshin-db" {
 		emojis         = "emojis",
 		voiceovers     = "voiceovers",
 
-		rarity         = "rarity", // deprecated
+		/** @deprecated */
+		rarity         = "rarity",
 		elements       = "elements",
 
 		tcgactioncards    = "tcgactioncards",

--- a/types/enums.d.ts
+++ b/types/enums.d.ts
@@ -54,6 +54,7 @@ declare module "genshin-db" {
 		tcgcardboxes      = "tcgcardboxes",
 		tcgcharactercards = "tcgcharactercards",
 		tcgdetailedrules  = "tcgdetailedrules",
+		tcgenemycards     = "tcgenemycards",
 		tcgkeywords       = "tcgkeywords",
 		tcglevelrewards   = "tcglevelrewards",
 		tcgstatuseffects  = "tcgstatuseffects",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -125,7 +125,7 @@ declare module "genshin-db" {
 	export const constellations: QueryFunction<Constellation>;
 	export const crafts: QueryFunction<Craft>;
 	export const domains: QueryFunction<Domain>;
-	export const elements: QueryFunction<Element>;
+	export const elements: QueryFunction<Element>; 
 	export const enemies: QueryFunction<Enemy>;
 	export const foods: QueryFunction<Food>;
 	export const geographies: QueryFunction<Geography>;
@@ -147,6 +147,7 @@ declare module "genshin-db" {
 	export const tcgcardboxes: QueryFunction<TcgCardBoxes>;
 	export const tcgcharactercards: QueryFunction<TcgCharacterCards>;
 	export const tcgdetailedrules: QueryFunction<TcgDetailedRules>;
+	export const tcgenemycards: QueryFunction<TcgEnemyCards>;
 	export const tcgkeywords: QueryFunction<TcgKeywords>;
 	export const tcglevelrewards: QueryFunction<TcgLevelRewards>;
 	export const tcgstatuseffects: QueryFunction<TcgStatusEffects>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -132,6 +132,7 @@ declare module "genshin-db" {
 	export const materials: QueryFunction<Material>;
 	export const namecards: QueryFunction<Namecard>;
 	export const outfits: QueryFunction<Outfit>;
+	/** @deprecated */
 	export const rarity: QueryFunction<Rarity>;
 	export const talentmaterialtypes: QueryFunction<TalentMaterial>;
 	export const talents: QueryFunction<Talent>;


### PR DESCRIPTION
I noticed the `tcgenemycards` types were not added to the type definitions despite a folder existing.

I also changed the `// deprecated` comment for `rarirty` to a `@deprecated` JSDoc comment so it adds a strikethrough in the editor when using them.