### PR TITLE
Move constants out to separate file, add some types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "genshin-db",
-	"version": "5.1.0",
+	"version": "5.1.8",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "genshin-db",
-			"version": "5.1.0",
+			"version": "5.1.8",
 			"license": "MIT",
 			"dependencies": {
 				"fuzzysort": "^1.1.4",

--- a/src/Options.js
+++ b/src/Options.js
@@ -5,17 +5,17 @@ class Options {
     /**
      * 
      * 
-     * @param {boolean} dumpResult - If true, returns additional data such as the query, folder, what matched, the options, and the filename. The results of the search is found in the 'result' property. 
-     * @param {boolean} matchNames - Allows autocomplete matching of data names.
-     * @param {boolean} matchAltNames - Allows autocomplete matching of alternate or custom names.
-     * @param {boolean} matchAliases - Allows autocomplete matching of data-defined aliases.
-     * @param {boolean} matchCategories - Allows autocomplete matching of categories. If true, returns an array of the categories that matched.
-     * @param {boolean} verboseCategories - Used if a category is matched. If true, then replaces each string name in the array with the data object instead
-     * @param {Array<String>} queryLanguages - The languages you wish your query will be searched in. See [Supported Languages](https://github.com/theBowja/genshin-db/blob/main/readme.md#genshindbsetoptionsopts)
-     * @param {String} resultLanguage - Output language that your results will be in. 
-     * @param {boolean} v4Props - Adds genshin-db v4 data properties to the return result of the API.
-     * @param {boolean} v4PropsOnly - Same as v4Props but removes v5 data properties.
-     * @param {boolean} matchExactOnly - 
+     * @param {boolean=} dumpResult - If true, returns additional data such as the query, folder, what matched, the options, and the filename. The results of the search is found in the 'result' property. 
+     * @param {boolean=} matchNames - Allows autocomplete matching of data names.
+     * @param {boolean=} matchAltNames - Allows autocomplete matching of alternate or custom names.
+     * @param {boolean=} matchAliases - Allows autocomplete matching of data-defined aliases.
+     * @param {boolean=} matchCategories - Allows autocomplete matching of categories. If true, returns an array of the categories that matched.
+     * @param {boolean=} verboseCategories - Used if a category is matched. If true, then replaces each string name in the array with the data object instead
+     * @param {Array<string>=} queryLanguages - The languages you wish your query will be searched in. See [Supported Languages](https://github.com/theBowja/genshin-db/blob/main/readme.md#genshindbsetoptionsopts)
+     * @param {string=} resultLanguage - Output language that your results will be in. 
+     * @param {boolean=} v4Props - Adds genshin-db v4 data properties to the return result of the API.
+     * @param {boolean=} v4PropsOnly - Same as v4Props but removes v5 data properties.
+     * @param {boolean=} matchExactOnly - 
      */
     constructor(dumpResult=undefined,
                 matchNames=undefined,

--- a/src/altnames.js
+++ b/src/altnames.js
@@ -113,9 +113,16 @@ altnames.addAltName('English', 'constellations', 'Baal', 'raidenshogun');
 altnames.addAltName('English', 'talents', 'Anemo Traveler', 'traveleranemo');
 altnames.addAltName('English', 'talents', 'Electro Traveler', 'travelerelectro');
 altnames.addAltName('English', 'talents', 'Geo Traveler', 'travelergeo');
+altnames.addAltName('English', 'talents', 'Hydro Traveler', 'travelerhydro');
+// TODO: when pyro traveler is added
+// altnames.addAltName('English', 'talents', 'Pyro Traveler', 'travelerpyro');
+
 altnames.addAltName('English', 'constellations', 'Anemo Traveler', 'traveleranemo');
 altnames.addAltName('English', 'constellations', 'Electro Traveler', 'travelerelectro');
 altnames.addAltName('English', 'constellations', 'Geo Traveler', 'travelergeo');
+altnames.addAltName('English', 'constellations', 'Hydro Traveler', 'travelerhydro');
+// TODO: when pyro traveler is added
+// altnames.addAltName('English', 'constellations', 'Pyro Traveler', 'travelerpyro');
 
 altnames.addAltName('English', 'enemies', 'Dvalin', 'stormterror');
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,119 @@
+// enum for folders. // make sure update index.d.ts too
+// not really used internally. mainly for altnames api
+const FoldersEnum = {
+	characters     : 'characters',
+	talents        : 'talents',
+	constellations : 'constellations',
+	
+	weapons        : 'weapons',
+
+	foods          : 'foods',
+	materials      : 'materials',
+	crafts         : 'crafts',
+
+	artifacts      : 'artifacts',
+	domains        : 'domains',
+	enemies        : 'enemies',
+
+	rarity         : 'rarity',
+	elements       : 'elements',
+
+	achievements   : 'achievements',
+	achievementgroups: 'achievementgroups',
+
+	windgliders    : 'windgliders',
+	outfits        : 'outfits',
+	animals        : 'animals',
+	namecards      : 'namecards',
+	geographies    : 'geographies',
+	adventureranks : 'adventureranks',
+
+	emojis         : 'emojis',
+	voiceovers     : 'voiceovers',
+
+	tcgactioncards:    'tcgactioncards',
+	tcgcardbacks:      'tcgcardbacks',
+	tcgcardboxes:      'tcgcardboxes',
+	tcgcharactercards: 'tcgcharactercards',
+	tcgdetailedrules:  'tcgdetailedrules',
+	tcgenemycards:     'tcgenemycards',
+	tcgkeywords:       'tcgkeywords',
+	tcglevelrewards:   'tcglevelrewards',
+	tcgstatuseffects:  'tcgstatuseffects',
+	tcgsummons:        'tcgsummons'
+};
+
+const folders = Object.values(FoldersEnum);
+
+const LanguagesEnum = {
+	'ChineseSimplified'  : 'ChineseSimplified',
+	'ChineseTraditional' : 'ChineseTraditional',
+	'English'            : 'English',
+	'French'             : 'French',
+	'German'             : 'German',
+	'Indonesian'         : 'Indonesian',
+	'Italian'            : 'Italian',
+	'Japanese'           : 'Japanese',
+	'Korean'             : 'Korean',
+	'Portuguese'         : 'Portuguese',
+	'Russian'            : 'Russian',
+	'Spanish'            : 'Spanish',
+	'Thai'               : 'Thai',
+	'Turkish'            : 'Turkish',
+	'Vietnamese'         : 'Vietnamese'
+};
+
+// converts Genshin's language codes into expanded strings
+const languageMap = {
+	'CHS': 'ChineseSimplified',
+	'CHT': 'ChineseTraditional',
+	'DE':  'German',
+	'EN':  'English',
+	'ES':  'Spanish',
+	'FR':  'French',
+	'ID':  'Indonesian',
+	'IT':  'Italian',
+	'JP':  'Japanese',
+	'KR':  'Korean',
+	'PT':  'Portuguese',
+	'RU':  'Russian',
+	'TH':  'Thai',
+	'TR':  'Turkish',
+	'VI':  'Vietnamese'
+};
+// array of language strings
+const languages = Object.values(languageMap);
+// array of language codes
+const languageCodes = Object.keys(languageMap);
+
+// // converts expanded strings into javascript locale codes
+const localeMap = {
+	'ChineseSimplified':  'zh-cn',
+	'ChineseTraditional': 'zh-tw',
+	'German':             'de',
+	'English':            'en',
+	'Spanish':            'es',
+	'French':             'fr',
+	'Indonesian':         'id',
+	'Italian':            'it',
+	'Japanese':           'ja',
+	'Korean':             'ko',
+	'Portuguese':         'pt',
+	'Russian':            'ru',
+	'Thai':               'th',
+	'Turkish':            'tr',
+	'Vietnamese':         'vi'
+};
+
+const languageDict = Object.keys(languageMap).concat(Object.values(languageMap));
+
+module.exports = {
+	FoldersEnum,
+	folders, // Object.values(FoldersEnum)
+	languageMap,
+	languageCodes,
+	LanguagesEnum,
+	languages,
+	localeMap,
+	languageDict
+}

--- a/src/folder.js
+++ b/src/folder.js
@@ -1,51 +1,5 @@
 const fuzzysort = require('fuzzysort');
-
-// enum for folders. // make sure update index.d.ts too
-// not really used internally. mainly for altnames api
-const FoldersEnum = {
-	characters     : 'characters',
-	talents        : 'talents',
-	constellations : 'constellations',
-	
-	weapons        : 'weapons',
-
-	foods          : 'foods',
-	materials      : 'materials',
-	crafts         : 'crafts',
-
-	artifacts      : 'artifacts',
-	domains        : 'domains',
-	enemies        : 'enemies',
-
-	rarity         : 'rarity',
-	elements       : 'elements',
-
-	achievements   : 'achievements',
-	achievementgroups: 'achievementgroups',
-
-	windgliders    : 'windgliders',
-	outfits        : 'outfits',
-	animals        : 'animals',
-	namecards      : 'namecards',
-	geographies    : 'geographies',
-	adventureranks : 'adventureranks',
-
-	emojis         : 'emojis',
-	voiceovers     : 'voiceovers',
-
-	tcgactioncards:    'tcgactioncards',
-	tcgcardbacks:      'tcgcardbacks',
-	tcgcardboxes:      'tcgcardboxes',
-	tcgcharactercards: 'tcgcharactercards',
-	tcgdetailedrules:  'tcgdetailedrules',
-	tcgenemycards:     'tcgenemycards',
-	tcgkeywords:       'tcgkeywords',
-	tcglevelrewards:   'tcglevelrewards',
-	tcgstatuseffects:  'tcgstatuseffects',
-	tcgsummons:        'tcgsummons'
-};
-
-const folders = Object.values(FoldersEnum);
+const { folders, FoldersEnum } = require('./constants');
 
 function autocompleteFolder(input) {
     let result = fuzzysort.go(input, folders, { limit: 1 })[0];
@@ -54,7 +8,7 @@ function autocompleteFolder(input) {
 
 /**
  * @param folders - a string or array of strings
- * @returns - autocompleted full name of the folder. see FoldersEnum.
+ * @returns {string | string[] | undefined} - autocompleted full name of the folder. see FoldersEnum.
  *            undefined if none of the strings are valid folders.
  */
 function format(folders) {
@@ -72,7 +26,7 @@ function format(folders) {
 }
 
 module.exports = {
-	FoldersEnum: FoldersEnum,
-	folders: folders, // Object.values(FoldersEnum)
-	format: format
+	FoldersEnum,
+	folders, // Object.values(FoldersEnum)
+	format
 };

--- a/src/getdata.js
+++ b/src/getdata.js
@@ -377,9 +377,9 @@ function addData(newdata, override = true) {
 }
 
 module.exports = {
-    addData: addData,
-    getData: getData,
-    getIndex: getIndex,
-    getImage: getImage,
-    getStats: getStats
+    addData,
+    getData,
+    getIndex,
+    getImage,
+    getStats
 }

--- a/src/helper.js
+++ b/src/helper.js
@@ -165,11 +165,4 @@ helper.formatTalentLabels = function(attributes, talentlevel) {
 	return outlabels;
 }
 
-
-
-
-
-
-
-
 module.exports = helper;

--- a/src/language.js
+++ b/src/language.js
@@ -1,66 +1,7 @@
+// @ts-check
 const fuzzysort = require('fuzzysort');
+const { languageMap, LanguagesEnum, languages, languageCodes, localeMap, languageDict } = require('./constants');
 
-const LanguagesEnum = {
-	'ChineseSimplified'  : 'ChineseSimplified',
-	'ChineseTraditional' : 'ChineseTraditional',
-	'English'            : 'English',
-	'French'             : 'French',
-	'German'             : 'German',
-	'Indonesian'         : 'Indonesian',
-	'Italian'            : 'Italian',
-	'Japanese'           : 'Japanese',
-	'Korean'             : 'Korean',
-	'Portuguese'         : 'Portuguese',
-	'Russian'            : 'Russian',
-	'Spanish'            : 'Spanish',
-	'Thai'               : 'Thai',
-	'Turkish'            : 'Turkish',
-	'Vietnamese'         : 'Vietnamese'
-};
-
-// converts Genshin's language codes into expanded strings
-const languageMap = {
-	'CHS': 'ChineseSimplified',
-	'CHT': 'ChineseTraditional',
-	'DE':  'German',
-	'EN':  'English',
-	'ES':  'Spanish',
-	'FR':  'French',
-	'ID':  'Indonesian',
-	'IT':  'Italian',
-	'JP':  'Japanese',
-	'KR':  'Korean',
-	'PT':  'Portuguese',
-	'RU':  'Russian',
-	'TH':  'Thai',
-	'TR':  'Turkish',
-	'VI':  'Vietnamese'
-};
-// array of language strings
-const languages = Object.values(languageMap);
-// array of language codes
-const languageCodes = Object.keys(languageMap);
-
-// // converts expanded strings into javascript locale codes
-const localeMap = {
-	'ChineseSimplified':  'zh-cn',
-	'ChineseTraditional': 'zh-tw',
-	'German':             'de',
-	'English':            'en',
-	'Spanish':            'es',
-	'French':             'fr',
-	'Indonesian':         'id',
-	'Italian':            'it',
-	'Japanese':           'ja',
-	'Korean':             'ko',
-	'Portuguese':         'pt',
-	'Russian':            'ru',
-	'Thai':               'th',
-	'Turkish':            'tr',
-	'Vietnamese':         'vi'
-};
-
-const languageDict = Object.keys(languageMap).concat(Object.values(languageMap));
 
 function autocompleteLanguage(input, dict) {
     let result = fuzzysort.go(input, dict, { limit: 1 })[0];
@@ -89,10 +30,10 @@ function format(langs) {
 }
 
 module.exports = {
-	LanguagesEnum: LanguagesEnum,
-	languages: languages, // array of strings
-	languageCodes: languageCodes,
-	languageMap: languageMap,
-	localeMap: localeMap,
-	format: format
+	LanguagesEnum,
+	languages, // array of strings
+	languageCodes,
+	languageMap,
+	localeMap,
+	format
 };

--- a/src/main.js
+++ b/src/main.js
@@ -85,9 +85,10 @@ const MatchType = {
 
 // TODO: if folder is undefined, search through every folder
 /**
- * @param query {string}
- * @param folders {string|string[]}
- * @param opts {object|Options}
+ * @param {string} query
+ * @param {string|string[]} folders
+ * @param {object|Options=} opts
+ * @param {boolean=} getfilename 
  */
 function retrieveData(query, folders, opts, getfilename) {
     opts = Object.assign({}, baseoptions, sanitizeOptions(opts));
@@ -189,7 +190,7 @@ genshin.getOptions = function () {
 /**
  * Get list of possible values for a category property.
  * @param {string} query -
- * @param {string|Folder} - 
+ * @param {string|Folder} folder - 
  * @param {object|Options} opts - The library options, see [Valid Options](https://github.com/theBowja/genshin-db/blob/main/readme.md#genshindbsetoptionsopts)
  * @returns {array|undefined} - 
  */
@@ -484,7 +485,7 @@ genshin.tcgsummons = genshin.tcgsummon = function (query, opts) {
 
 /**
  * Get data in any specified folder.
- * @param {string} folder - Folder name. For example: 'characters'.
+ * @param {string | string[]} folder - Folder name. For example: 'characters'.
  * @param {object|Options} opts - The library options, see [Valid Options](https://github.com/theBowja/genshin-db/blob/main/readme.md#genshindbsetoptionsopts)
  * @returns {object} - The data found based on the query string and options parameter.
  */

--- a/src/v4prop.js
+++ b/src/v4prop.js
@@ -3,11 +3,6 @@ const Folder = require('./folder.js').FoldersEnum;
 // Maps v5 property values to v4 property names for backwards compatibility purposes.
 // It's not a 100% match to v4 but it's good enough for a quick bandaid fix.
 
-module.exports = {
-	addv4: addv4,
-	getv4: getv4
-}
-
 function addv4(v5data, folder) {
 	const v4 = getv4(v5data, folder);
 	copyOverwriteObj(v4, v5data);
@@ -493,4 +488,9 @@ function mapadventureranks(v5data) {
 
 		version: v5data.version
 	};
+}
+
+module.exports = {
+	addv4,
+	getv4
 }


### PR DESCRIPTION
As mentioned in discord, this PR mostly moves some constants into a separate file so they can be imported without side effects.

It also fixes a couple jsdoc types and changes a few places to using shorthand object literal syntax (i.e. instead of `{ foo: foo }`, it would just be `{ foo }`)